### PR TITLE
Fixed DummyRegressor converting constant to Numpy type after fit

### DIFF
--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -606,20 +606,18 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     "when the constant strategy is used."
                 )
 
-            self.constant = check_array(
+            self.constant_ = check_array(
                 self.constant,
                 accept_sparse=["csr", "csc", "coo"],
                 ensure_2d=False,
                 ensure_min_samples=0,
             )
 
-            if self.n_outputs_ != 1 and self.constant.shape[0] != y.shape[1]:
+            if self.n_outputs_ != 1 and self.constant_.shape[0] != y.shape[1]:
                 raise ValueError(
                     "Constant target value should have shape (%d, 1)." % y.shape[1]
                 )
-
-            self.constant_ = self.constant
-
+                
         self.constant_ = np.reshape(self.constant_, (1, -1))
         return self
 


### PR DESCRIPTION
Fixed #22486

DummyRegressor fit() no longer converts constant to Numpy type
